### PR TITLE
Add simulation wavefiles to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .venv/
 target/
+*.fst


### PR DESCRIPTION
These wave files are produces by Verilator when tracing is enabled.